### PR TITLE
Fix MacOS Title Bar Theming

### DIFF
--- a/instance.cfg
+++ b/instance.cfg
@@ -1,3 +1,5 @@
 InstanceType=OneSix
+JvmArgs="-Dapple.awt.application.appearance=system"
+OverrideJavaArgs=true
 name=babric b1.7.3
 iconKey=fabric


### PR DESCRIPTION
Dark mode will make the titlebar themed correctly with this argument
<img width="866" alt="image" src="https://github.com/user-attachments/assets/e4d0499a-763b-4213-96c5-b0570a767b0a">
